### PR TITLE
Ignore stray file check if the file doesnt exist

### DIFF
--- a/src/Service/CleanService.php
+++ b/src/Service/CleanService.php
@@ -38,9 +38,15 @@ class CleanService
         $this->loop($this->project->YoYoProjectEntity()->getRoot()->gmResource());
 
         foreach ($this->project->ignored() as $leftOverFile) {
+            if (!file_exists($leftOverFile)) {
+                // Already gone, skip it
+                continue;
+            }
+
             if (strlen($leftOverFile) <= 1) {
                 continue;
             }
+
             $resource = false;
 
             // OK to delete datafiles


### PR DESCRIPTION
When installing a cloned repository (one where the ignored files are not in the repo) the stray file checker explodes, because it tries to load them.

Wrong in this case, so this should fix that!

Fixes https://github.com/GameMakerHub/Catalyst/issues/22